### PR TITLE
Reset as gpio

### DIFF
--- a/bl/blpwm.c
+++ b/bl/blpwm.c
@@ -25,6 +25,11 @@
 #define TIMx_CLK_ENABLE __HAL_RCC_TIM3_CLK_ENABLE
 #define CHANNEL 1
 #define AF LL_GPIO_AF_1
+#elif PIN_BL_LED == PA_10
+#define TIMx TIM1
+#define TIMx_CLK_ENABLE __HAL_RCC_TIM1_CLK_ENABLE
+#define CHANNEL 3
+#define AF LL_GPIO_AF_1
 #elif PIN_BL_LED == PB_1
 #define TIMx TIM3
 #define TIMx_CLK_ENABLE __HAL_RCC_TIM3_CLK_ENABLE

--- a/stm32/dspi.c
+++ b/stm32/dspi.c
@@ -30,13 +30,25 @@
 #endif
 
 #if SPI_IDX == 1
+#define SPI_CLK_ENABLE __HAL_RCC_SPI1_CLK_ENABLE
+#if PIN_ASCK == PA_5
 #define PIN_AF LL_GPIO_AF_0
 STATIC_ASSERT(PIN_ASCK == PA_5);
-STATIC_ASSERT(PIN_AMOSI == PA_7);
+
+STATIC_ASSERT(PIN_AMOSI == PA_7 || PIN_AMOSI == PA_2);
 #if SPI_RX
 STATIC_ASSERT(PIN_AMISO == PA_6);
 #endif
-#define SPI_CLK_ENABLE __HAL_RCC_SPI1_CLK_ENABLE
+#elif PIN_ASCK == PA_1
+#define PIN_AF LL_GPIO_AF_0
+STATIC_ASSERT(PIN_ASCK == PA_1);
+STATIC_ASSERT(PIN_AMOSI == PA_2);
+#if SPI_RX
+STATIC_ASSERT(PIN_AMISO == PA_6);
+#endif
+#else 
+#error "not supported"
+#endif
 #elif SPI_IDX == 2
 #error "not supported"
 #define SPI_CLK_ENABLE __HAL_RCC_SPI2_CLK_ENABLE
@@ -57,6 +69,11 @@ STATIC_ASSERT(PIN_AMISO == PA_6);
 #define DMA_CH LL_DMA_CHANNEL_1
 #define DMA_IRQn DMA1_Channel1_IRQn
 #define DMA_Handler DMA1_Channel1_IRQHandler
+
+// #define DMA_CH LL_DMA_CHANNEL_2
+// #define DMA_CH_RX LL_DMA_CHANNEL_3
+// #define DMA_IRQn DMA1_Channel2_3_IRQn
+// #define DMA_Handler DMA1_Channel2_3_IRQHandler
 #else
 
 #if SPI_IDX == 1

--- a/stm32/dspi.c
+++ b/stm32/dspi.c
@@ -7,7 +7,15 @@
 
 #ifdef PIN_ASCK
 
-#if defined(STM32F031x6) || defined(STM32F030x4) || defined(STM32G031xx) || !defined(SPI2)
+#if defined(STM32G031xx)
+#if PIN_ASCK == PA_5 || PIN_ASCK == PA_1
+#define SPI_IDX 1
+#elif PIN_ASCK == PA_0
+#define SPI_IDX 2
+#else
+    #error "Please add pin mapping for STM32G0 SPI"
+#endif
+#elif defined(STM32F031x6) || defined(STM32F030x4) || !defined(SPI2)
 #define SPI_IDX 1
 #else
 #define SPI_IDX 2
@@ -46,10 +54,25 @@ STATIC_ASSERT(PIN_AMOSI == PA_2);
 #if SPI_RX
 STATIC_ASSERT(PIN_AMISO == PA_6);
 #endif
-#else 
+#else
 #error "not supported"
 #endif
 #elif SPI_IDX == 2
+#define SPI_CLK_ENABLE __HAL_RCC_SPI2_CLK_ENABLE
+#if defined(STM32G031xx)
+#if PIN_ASCK == PA_0
+#define PIN_AF LL_GPIO_AF_0
+#define PIN_AF_MOSI LL_GPIO_AF_1
+STATIC_ASSERT(PIN_ASCK == PA_0);
+STATIC_ASSERT(PIN_AMOSI == PB_7);
+#if SPI_RX
+// not implemented
+STATIC_ASSERT(PIN_AMISO == -1);
+#endif
+#else
+#error "not supported"
+#endif
+#else
 #error "not supported"
 #define SPI_CLK_ENABLE __HAL_RCC_SPI2_CLK_ENABLE
 #ifdef STM32G0
@@ -60,6 +83,7 @@ STATIC_ASSERT(PIN_AMISO == PA_6);
 #define PIN_SCK LL_GPIO_PIN_13
 #define PIN_MOSI LL_GPIO_PIN_15
 #define PIN_AF LL_GPIO_AF_0
+#endif
 #endif
 #else
 #error "bad spi"
@@ -132,7 +156,14 @@ void dspi_init() {
     __HAL_RCC_DMA1_CLK_ENABLE();
 
     pin_setup_output_af(PIN_ASCK, PIN_AF);
+
+// some pins require an alternate AF enum for specific pins.
+#ifdef PIN_AF_MOSI
+    pin_setup_output_af(PIN_AMOSI, PIN_AF_MOSI);
+#else
     pin_setup_output_af(PIN_AMOSI, PIN_AF);
+#endif
+
 #if SPI_RX
     pin_setup_output_af(PIN_AMISO, PIN_AF);
 #endif
@@ -399,7 +430,13 @@ void px_init(int light_type) {
 
     px_state.type = light_type;
 
+    // some pins require an alternate AF enum for specific pins.
+#ifdef PIN_AF_MOSI
+    pin_setup_output_af(PIN_AMOSI, PIN_AF_MOSI);
+#else
     pin_setup_output_af(PIN_AMOSI, PIN_AF);
+#endif
+
     if (light_type & LIGHT_TYPE_APA_MASK)
         pin_setup_output_af(PIN_ASCK, PIN_AF);
 

--- a/stm32/init.c
+++ b/stm32/init.c
@@ -20,17 +20,27 @@ static void enable_nrst_pin(void) {
 #ifdef FLASH_OPTR_NRST_MODE
 #define FLASH_KEY1 0x45670123U
 #define FLASH_KEY2 0xCDEF89ABU
+    //print ((FLASH_TypeDef *)0x40022000UL)
+    DMESG("check NRST %x", FLASH->OPTR & FLASH_OPTR_NRST_MODE);
 
-    DMESG("check NRST", FLASH->OPTR & FLASH_OPTR_NRST_MODE);
-
+#ifdef RESET_AS_GPIO
+    if (FLASH->OPTR & FLASH_OPTR_NRST_MODE_1) {
+        return;
+    }
+#else
     // this is default production value, but we check it anyways
     if (FLASH->OPTR & FLASH_OPTR_NRST_MODE_0)
         return;
+#endif
 
     uint32_t nrstmode;
 
     /* Enable Flash access anyway */
     __HAL_RCC_FLASH_CLK_ENABLE();
+
+    // check no flash op is ongoing
+    while ((FLASH->SR & FLASH_SR_BSY1) != 0)
+        ;
 
     /* Unlock flash */
     FLASH->KEYR = FLASH_KEY1;
@@ -41,24 +51,33 @@ static void enable_nrst_pin(void) {
     /* unlock option byte registers */
     FLASH->OPTKEYR = 0x08192A3B;
     FLASH->OPTKEYR = 0x4C5D6E7F;
-    while ((FLASH->CR & FLASH_CR_OPTLOCK) == FLASH_CR_OPTLOCK)
-        ;
+    while ((FLASH->CR & FLASH_CR_OPTLOCK) == FLASH_CR_OPTLOCK);
 
     /* get current user option bytes */
     nrstmode = (FLASH->OPTR & ~FLASH_OPTR_NRST_MODE);
+
+#ifdef RESET_AS_GPIO
+    nrstmode |= FLASH_OPTR_NRST_MODE_1;
+#else
     nrstmode |= FLASH_OPTR_NRST_MODE_0;
+#endif
 
     /* Program option bytes */
     FLASH->OPTR = nrstmode;
 
-    /* Write operation */
+    // check no flash op is ongoing
+    while ((FLASH->SR & FLASH_SR_BSY1) != 0)
+        ;
+    // store options via options start
     FLASH->CR |= FLASH_CR_OPTSTRT;
+    // wait for complete
     while ((FLASH->SR & FLASH_SR_BSY1) != 0)
         ;
 
     /* Force OB Load */
     FLASH->CR |= FLASH_CR_OBL_LAUNCH;
 
+    // OBL triggers a reset
     while (1)
         ;
 #endif

--- a/stm32/init.c
+++ b/stm32/init.c
@@ -45,13 +45,10 @@ static void enable_nrst_pin(void) {
     /* Unlock flash */
     FLASH->KEYR = FLASH_KEY1;
     FLASH->KEYR = FLASH_KEY2;
-    while ((FLASH->CR & FLASH_CR_LOCK) != 0x00)
-        ;
 
     /* unlock option byte registers */
     FLASH->OPTKEYR = 0x08192A3B;
     FLASH->OPTKEYR = 0x4C5D6E7F;
-    while ((FLASH->CR & FLASH_CR_OPTLOCK) == FLASH_CR_OPTLOCK);
 
     /* get current user option bytes */
     nrstmode = (FLASH->OPTR & ~FLASH_OPTR_NRST_MODE);
@@ -64,10 +61,6 @@ static void enable_nrst_pin(void) {
 
     /* Program option bytes */
     FLASH->OPTR = nrstmode;
-
-    // check no flash op is ongoing
-    while ((FLASH->SR & FLASH_SR_BSY1) != 0)
-        ;
     // store options via options start
     FLASH->CR |= FLASH_CR_OPTSTRT;
     // wait for complete


### PR DESCRIPTION
Allow multiplexed NRST pads to be used as GPIO on smaller G03x packages. 