### PR TITLE
add check for OPTR_LEGACY_MODE

### DIFF
--- a/stm32/init.c
+++ b/stm32/init.c
@@ -18,13 +18,12 @@ void SysTick_Handler(void) {}
 
 #define OPTR_MODE0 0x1
 #define OPTR_MODE1 0x2
+#define OPTR_MODE_LEGACY 0x3
 
 static void enable_nrst_pin(void) {
 #ifdef FLASH_OPTR_NRST_MODE
 #define FLASH_KEY1 0x45670123U
 #define FLASH_KEY2 0xCDEF89ABU
-    //print ((FLASH_TypeDef *)0x40022000UL)
-    DMESG("check NRST %x", FLASH->OPTR & FLASH_OPTR_NRST_MODE);
 
     int msk = (FLASH->OPTR & FLASH_OPTR_NRST_MODE) >> FLASH_OPTR_NRST_MODE_Pos;
 
@@ -34,7 +33,7 @@ static void enable_nrst_pin(void) {
         return;
 #else 
     // Reset as conventional reset line
-    if (msk == OPTR_MODE0)
+    if (msk == OPTR_MODE0 || msk == OPTR_MODE_LEGACY)
         return;
 #endif
 


### PR DESCRIPTION
There is a temporal relationship with flash-loop and the microcontroller which results in bricked MCUs. I think it is because power is interrupted or the microcontroller is reset when writing to OPTR. The frequency of bricking has increased because we have changed from a logical and with OPTR_MODE to an equality check for OPTR_MODE1 (0x1). The default value is OPTR_MODE_LEGACY (0x3), causing OPTR writes now on every flash...

A safer process would be to remain in OPTR_LEGACY, as this is compatible with OPTR_MODE1 behaviour.