### PR TITLE
add cpu freq check to timer set

### DIFF
--- a/stm32/tim.c
+++ b/stm32/tim.c
@@ -124,11 +124,18 @@ void TIMx_IRQHandler(void) {
 
 void tim_update_prescaler(void) {
     target_disable_irq();
-    LL_TIM_DisableCounter(TIMx);
-    LL_TIM_SetPrescaler(TIMx, cpu_mhz - 1);
+    // first store, the time
     uint64_t us = tim_get_micros();
-    timeoff = us - 0xffff;
-    LL_TIM_GenerateEvent_UPDATE(TIMx); // the update evt will also clear timer cnt
+
+    // set the prescaler
+    LL_TIM_SetPrescaler(TIMx, cpu_mhz - 1);
+
+    // arrange for the update event to be generated very soon to load the new prescaler
+    timeoff = us - 0xfffd;
+    LL_TIM_DisableCounter(TIMx);
+    TIMx->CNT = 0xfffe;
     LL_TIM_EnableCounter(TIMx);
+    LL_TIM_ClearFlag_UPDATE(TIMx);
+
     target_enable_irq();
 }

--- a/stm32/tim.c
+++ b/stm32/tim.c
@@ -60,6 +60,11 @@ void tim_set_timer(int delta, cb_t cb) {
     if (delta == JD_MIN_MAX_SLEEP)
         delta = jd_max_sleep;
 
+    // cpu_mhz always init with HSI
+    if (cpu_mhz != HSI_MHZ){
+        delta = (delta * cpu_mhz) / HSI_MHZ;
+    }
+
     rtc_cancel_cb();
     target_disable_irq();
     timer_cb = cb;

--- a/stm32/tim.c
+++ b/stm32/tim.c
@@ -60,11 +60,6 @@ void tim_set_timer(int delta, cb_t cb) {
     if (delta == JD_MIN_MAX_SLEEP)
         delta = jd_max_sleep;
 
-    // cpu_mhz always init with HSI
-    if (cpu_mhz != HSI_MHZ){
-        delta = (delta * cpu_mhz) / HSI_MHZ;
-    }
-
     rtc_cancel_cb();
     target_disable_irq();
     timer_cb = cb;
@@ -130,5 +125,6 @@ void TIMx_IRQHandler(void) {
 void tim_update_prescaler(void) {
     LL_TIM_DisableCounter(TIMx);
     LL_TIM_SetPrescaler(TIMx, cpu_mhz - 1);
+    LL_TIM_GenerateEvent_UPDATE(TIMx);
     LL_TIM_EnableCounter(TIMx);
 }

--- a/stm32/tim.c
+++ b/stm32/tim.c
@@ -123,8 +123,12 @@ void TIMx_IRQHandler(void) {
 }
 
 void tim_update_prescaler(void) {
+    target_disable_irq();
     LL_TIM_DisableCounter(TIMx);
     LL_TIM_SetPrescaler(TIMx, cpu_mhz - 1);
-    LL_TIM_GenerateEvent_UPDATE(TIMx);
+    uint64_t us = tim_get_micros();
+    timeoff = us - 0xffff;
+    LL_TIM_GenerateEvent_UPDATE(TIMx); // the update evt will also clear timer cnt
     LL_TIM_EnableCounter(TIMx);
+    target_enable_irq();
 }


### PR DESCRIPTION
The timer pre-scaler could be varying during runtime, especially for such case:
 https://github.com/microsoft/jacdac/issues/1293

The servo enable update the pll from 16MHz to 48M, which is 3 times faster than origin one. And leads to subsequence packet receiver working in a wrong timeout params, that is header wait timeout from 250us to 86us and full packet timeout from around 300us to 100us.

![image](https://github.com/microsoft/jacdac-stm32x0/assets/3390845/17c53ecc-0dd4-4ac2-9321-23a7ed908ab6)
